### PR TITLE
Wire CLI entry point — flag parsing, subcommand dispatch

### DIFF
--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -10,13 +10,16 @@ import (
 )
 
 // InitLogging creates a *slog.Logger configured for the given level string.
-// It uses a text handler when stderr is a TTY, and a JSON handler otherwise.
+// It uses a text handler when w is a TTY, and a JSON handler otherwise.
 // Supported levels: debug, info, warn, error. Unknown levels default to info.
-func InitLogging(level string) *slog.Logger {
+func InitLogging(level string, w io.Writer) *slog.Logger {
 	lvl := parseLevel(level)
 	opts := &slog.HandlerOptions{Level: lvl}
-	isTTY := term.IsTerminal(int(os.Stderr.Fd()))
-	h := newHandler(os.Stderr, isTTY, opts)
+	isTTY := false
+	if f, ok := w.(*os.File); ok {
+		isTTY = term.IsTerminal(int(f.Fd()))
+	}
+	h := newHandler(w, isTTY, opts)
 	return slog.New(h)
 }
 

--- a/internal/config/logging_test.go
+++ b/internal/config/logging_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -14,7 +15,7 @@ func TestFR5_InitLoggingReturnsLogger(t *testing.T) {
 	levels := []string{"debug", "info", "warn", "error", "INFO", "Debug", "unknown", ""}
 	for _, level := range levels {
 		t.Run(level, func(t *testing.T) {
-			logger := InitLogging(level)
+			logger := InitLogging(level, io.Discard)
 			if logger == nil {
 				t.Fatal("InitLogging returned nil")
 			}
@@ -40,7 +41,7 @@ func TestFR5_LevelParsing(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger := InitLogging(tt.level)
+			logger := InitLogging(tt.level, io.Discard)
 			if !logger.Enabled(nil, tt.wantLevel) {
 				t.Errorf("level %s should be enabled for input %q", tt.wantLevel, tt.level)
 			}
@@ -120,7 +121,7 @@ func TestFR5_ComponentAttribute(t *testing.T) {
 // default slog logger (D3 requirement).
 func TestFR5_NoGlobalLoggerState(t *testing.T) {
 	defaultBefore := slog.Default()
-	_ = InitLogging("info")
+	_ = InitLogging("info", io.Discard)
 	defaultAfter := slog.Default()
 	if defaultBefore != defaultAfter {
 		t.Error("InitLogging must not call slog.SetDefault")

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	logger := config.InitLogging(*logLevel)
+	logger := config.InitLogging(*logLevel, stderr)
 
 	cfg, err := config.Load(*cfgPath)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/dmitriyb/conductor/internal/config"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run parses flags and dispatches to the appropriate subcommand.
+// It returns the exit code. Extracted from main() for testability.
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("conductor", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	cfgPath := fs.String("config", "orchestrator.yaml", "config file path")
+	logLevel := fs.String("log-level", "info", "log level")
+
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	subcmds := fs.Args()
+	if len(subcmds) == 0 {
+		fmt.Fprintln(stderr, "usage: conductor [flags] <subcommand>")
+		fmt.Fprintln(stderr, "subcommands: validate, build, run")
+		return 1
+	}
+
+	switch subcmds[0] {
+	case "validate", "build", "run":
+		// valid subcommand — continue below
+	default:
+		fmt.Fprintf(stderr, "unknown subcommand: %q\n", subcmds[0])
+		fmt.Fprintln(stderr, "subcommands: validate, build, run")
+		return 1
+	}
+
+	logger := config.InitLogging(*logLevel)
+
+	cfg, err := config.Load(*cfgPath)
+	if err != nil {
+		logger.Error("failed to load config", "error", err)
+		return 1
+	}
+
+	if err := config.Validate(cfg); err != nil {
+		logger.Error("config validation failed", "error", err)
+		return 1
+	}
+
+	switch subcmds[0] {
+	case "validate":
+		fmt.Fprintln(stdout, "configuration is valid")
+	case "build":
+		fmt.Fprintln(stderr, "build: not yet implemented")
+		return 1
+	case "run":
+		fmt.Fprintln(stderr, "run: not yet implemented")
+		return 1
+	}
+
+	return 0
+}

--- a/main_test.go
+++ b/main_test.go
@@ -68,14 +68,7 @@ func TestFR4_ValidateDefaultConfig(t *testing.T) {
 	}
 
 	// Change to the temp directory so the default path resolves.
-	orig, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	t.Cleanup(func() { os.Chdir(orig) })
+	t.Chdir(dir)
 
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"validate"}, &stdout, &stderr)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// validYAML is a minimal orchestrator.yaml that passes Validate.
+const validYAML = `
+project:
+  name: test-project
+  repository: https://github.com/test/repo.git
+
+credentials:
+  backend: env
+
+docker:
+  base_image: debian:bookworm-slim
+
+agents:
+  worker:
+    prompt:
+      system: system.md
+      task: "do the thing"
+    workspace: rw
+
+pipeline:
+  - { name: build, agent: worker }
+`
+
+// writeConfig writes YAML content to a temp file and returns its path.
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "orchestrator.yaml")
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return p
+}
+
+// TestFR4_ValidateSubcommandSuccess verifies that `conductor validate --config path`
+// exits 0 and prints a success message for a valid config.
+func TestFR4_ValidateSubcommandSuccess(t *testing.T) {
+	cfgPath := writeConfig(t, validYAML)
+	var stdout, stderr bytes.Buffer
+
+	code := run([]string{"--config", cfgPath, "validate"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("want exit 0, got %d; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "configuration is valid") {
+		t.Fatalf("stdout = %q, want it to contain %q", stdout.String(), "configuration is valid")
+	}
+}
+
+// TestFR4_ValidateDefaultConfig verifies that `conductor validate` defaults
+// to ./orchestrator.yaml when --config is not specified.
+func TestFR4_ValidateDefaultConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "orchestrator.yaml")
+	if err := os.WriteFile(cfgPath, []byte(validYAML), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Change to the temp directory so the default path resolves.
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) })
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"validate"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("want exit 0, got %d; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "configuration is valid") {
+		t.Fatalf("stdout = %q, want it to contain %q", stdout.String(), "configuration is valid")
+	}
+}
+
+// TestFR4_ValidateInvalidConfig verifies that `conductor validate` exits
+// non-zero when the config has validation errors.
+func TestFR4_ValidateInvalidConfig(t *testing.T) {
+	invalidYAML := `
+project:
+  name: ""
+  repository: ""
+credentials:
+  backend: env
+docker:
+  base_image: debian:bookworm-slim
+agents:
+  worker:
+    prompt:
+      system: s.md
+      task: do
+    workspace: rw
+pipeline:
+  - { name: build, agent: worker }
+`
+	cfgPath := writeConfig(t, invalidYAML)
+	var stdout, stderr bytes.Buffer
+
+	code := run([]string{"--config", cfgPath, "validate"}, &stdout, &stderr)
+
+	if code == 0 {
+		t.Fatal("want non-zero exit for invalid config, got 0")
+	}
+}
+
+// TestFR4_ValidateMissingConfig verifies that `conductor validate` exits
+// non-zero when the config file does not exist.
+func TestFR4_ValidateMissingConfig(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--config", "/nonexistent/path.yaml", "validate"}, &stdout, &stderr)
+
+	if code == 0 {
+		t.Fatal("want non-zero exit for missing config, got 0")
+	}
+}
+
+// TestFR4_RunSubcommandRecognized verifies that the `run` subcommand is
+// recognized and loads config before reporting unimplemented.
+func TestFR4_RunSubcommandRecognized(t *testing.T) {
+	cfgPath := writeConfig(t, validYAML)
+	var stdout, stderr bytes.Buffer
+
+	_ = run([]string{"--config", cfgPath, "run"}, &stdout, &stderr)
+
+	// run is a stub that exits non-zero, but should not report "unknown subcommand"
+	if strings.Contains(stderr.String(), "unknown subcommand") {
+		t.Fatalf("run should be recognized, stderr: %s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "not yet implemented") {
+		t.Fatalf("stderr = %q, want it to contain %q", stderr.String(), "not yet implemented")
+	}
+}
+
+// TestFR4_BuildSubcommandRecognized verifies that the `build` subcommand is
+// recognized and loads config before reporting unimplemented.
+func TestFR4_BuildSubcommandRecognized(t *testing.T) {
+	cfgPath := writeConfig(t, validYAML)
+	var stdout, stderr bytes.Buffer
+
+	_ = run([]string{"--config", cfgPath, "build"}, &stdout, &stderr)
+	if strings.Contains(stderr.String(), "unknown subcommand") {
+		t.Fatalf("build should be recognized, stderr: %s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "not yet implemented") {
+		t.Fatalf("stderr = %q, want it to contain %q", stderr.String(), "not yet implemented")
+	}
+}
+
+// TestFR4_UnknownSubcommand verifies that an unknown subcommand prints
+// usage and exits non-zero.
+func TestFR4_UnknownSubcommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"frobnicate"}, &stdout, &stderr)
+
+	if code == 0 {
+		t.Fatal("want non-zero exit for unknown subcommand, got 0")
+	}
+	if !strings.Contains(stderr.String(), "unknown subcommand") {
+		t.Fatalf("stderr = %q, want it to contain %q", stderr.String(), "unknown subcommand")
+	}
+	if !strings.Contains(stderr.String(), "frobnicate") {
+		t.Fatalf("stderr = %q, want it to contain the bad subcommand name", stderr.String())
+	}
+}
+
+// TestFR4_NoSubcommand verifies that running with no subcommand prints
+// usage and exits non-zero.
+func TestFR4_NoSubcommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{}, &stdout, &stderr)
+
+	if code == 0 {
+		t.Fatal("want non-zero exit for missing subcommand, got 0")
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Fatalf("stderr = %q, want it to contain usage info", stderr.String())
+	}
+}
+
+// TestFR4_LogLevelFlag verifies that the --log-level flag is accepted
+// and does not cause an error.
+func TestFR4_LogLevelFlag(t *testing.T) {
+	cfgPath := writeConfig(t, validYAML)
+	for _, level := range []string{"debug", "info", "warn", "error"} {
+		t.Run(level, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run([]string{"--log-level", level, "--config", cfgPath, "validate"}, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("want exit 0 with --log-level %s, got %d; stderr: %s", level, code, stderr.String())
+			}
+		})
+	}
+}
+
+// TestFR6_NoGlobalState verifies that *Config is loaded via the --config
+// flag and passed explicitly — not via global state. Multiple invocations
+// with different configs produce independent results.
+func TestFR6_NoGlobalState(t *testing.T) {
+	// First call with valid config
+	validPath := writeConfig(t, validYAML)
+	var stdout1, stderr1 bytes.Buffer
+	code1 := run([]string{"--config", validPath, "validate"}, &stdout1, &stderr1)
+
+	// Second call with a missing config
+	var stdout2, stderr2 bytes.Buffer
+	code2 := run([]string{"--config", "/nonexistent.yaml", "validate"}, &stdout2, &stderr2)
+
+	if code1 != 0 {
+		t.Fatalf("first run: want exit 0, got %d", code1)
+	}
+	if code2 == 0 {
+		t.Fatal("second run: want non-zero exit, got 0")
+	}
+}


### PR DESCRIPTION
## Linked Issue

Closes #5

## Spec Traceability

**Requirement(s) fulfilled**: FR4, FR6
**Plan step(s) completed**: Step 1.5

## Changes

- Add `main.go` with CLI entry point: `--config` flag (default `orchestrator.yaml`), `--log-level` flag (default `info`), and subcommand dispatch (`validate`, `build`, `run`)
- `validate` subcommand loads, validates, prints result, exits 0 on success / non-zero on failure
- `build` and `run` subcommands are recognized stubs (exit non-zero with "not yet implemented")
- Unknown subcommand prints usage and exits non-zero
- Config passed explicitly via flag — no global state (FR6)
- Extracted `run()` function for testability

## Testing

- [x] Tests added that verify requirement fulfillment
- [x] Existing tests pass
- [x] Test names reference requirement IDs

Tests cover:
- `TestFR4_ValidateSubcommandSuccess` — valid config exits 0, prints success
- `TestFR4_ValidateDefaultConfig` — defaults to `./orchestrator.yaml`
- `TestFR4_ValidateInvalidConfig` — invalid config exits non-zero
- `TestFR4_ValidateMissingConfig` — missing file exits non-zero
- `TestFR4_RunSubcommandRecognized` — `run` recognized, reports unimplemented
- `TestFR4_BuildSubcommandRecognized` — `build` recognized, reports unimplemented
- `TestFR4_UnknownSubcommand` — exits non-zero with usage
- `TestFR4_NoSubcommand` — exits non-zero with usage
- `TestFR4_LogLevelFlag` — all log levels accepted
- `TestFR6_NoGlobalState` — independent calls produce independent results

## Checklist

- [x] Code traces to spec requirements
- [x] No unrelated changes included
- [x] Documentation updated if needed